### PR TITLE
fix: resolving the false coverage of the test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/strict-boolean-expressions": "off",
     "@typescript-eslint/no-misused-promises": "off",
-    "@typescript-eslint/no-invalid-void-type": "off"
+    "@typescript-eslint/no-invalid-void-type": "off",
+    "@typescript-eslint/prefer-optional-chain": "off"
   }
 }

--- a/src/application/middlewares/auth.ts
+++ b/src/application/middlewares/auth.ts
@@ -40,6 +40,9 @@ export class AuthMiddleware implements Middleware {
       if (!payload) {
         return unauthorized(new InvalidTokenError('Invalid or expired token'))
       }
+      if (!payload.sub) {
+        return unauthorized(new InvalidTokenError('Invalid or expired token'))
+      }
 
       const { sub: userId } = payload
       const account = await this.guardianRepository.loadById(userId)

--- a/src/application/middlewares/auth.ts
+++ b/src/application/middlewares/auth.ts
@@ -37,10 +37,7 @@ export class AuthMiddleware implements Middleware {
       }
 
       const payload = await this.tokenService.decode(authorization)
-      if (!payload) {
-        return unauthorized(new InvalidTokenError('Invalid or expired token'))
-      }
-      if (!payload.sub) {
+      if (!payload || !payload.sub) {
         return unauthorized(new InvalidTokenError('Invalid or expired token'))
       }
 

--- a/tests/src/main/middlewares/auth.test.ts
+++ b/tests/src/main/middlewares/auth.test.ts
@@ -3,6 +3,7 @@ import app from '@/main/config/app'
 import { auth } from '@/main/middlewares'
 import { sign } from 'jsonwebtoken'
 import { PrismaHelper } from '@/tests/helpers/prisma-helper'
+import env from '@/main/config/env'
 
 beforeEach(async () => { await PrismaHelper.connect() })
 
@@ -30,7 +31,7 @@ describe('Authentication Middleware', () => {
   })
 
   it('Should return 401 if token payload is empty', async () => {
-    const tokenWithPayloadEmpty = sign({ payload: {} }, 'secret')
+    const tokenWithPayloadEmpty = sign({ payload: {} }, env.secret)
     app.get('/test_auth', auth, (req, res) => {
       res.send({ userId: req.userId })
     })

--- a/tests/src/main/middlewares/auth.test.ts
+++ b/tests/src/main/middlewares/auth.test.ts
@@ -1,9 +1,9 @@
 import request from 'supertest'
 import app from '@/main/config/app'
 import { auth } from '@/main/middlewares'
-import { sign } from 'jsonwebtoken'
 import { PrismaHelper } from '@/tests/helpers/prisma-helper'
 import env from '@/main/config/env'
+import { JwtAdapter } from '@/infra/cryptography'
 
 beforeEach(async () => { await PrismaHelper.connect() })
 
@@ -31,7 +31,8 @@ describe('Authentication Middleware', () => {
   })
 
   it('Should return 401 if token payload is empty', async () => {
-    const tokenWithPayloadEmpty = sign({ payload: {} }, env.secret)
+    const jwtAdapter = new JwtAdapter(env.secret)
+    const tokenWithPayloadEmpty = await jwtAdapter.generate({ payload: {} })
     app.get('/test_auth', auth, (req, res) => {
       res.send({ userId: req.userId })
     })


### PR DESCRIPTION
The test "Should return 401 if token payload is empty" in the file "auth.test.ts" is giving a false positive because the environment variable is not being used in the test. This resulted in a false coverage of the test because the test only passed if the environment variable "SECRET" was different from "SECRET=secret".

this.secret is different in .env and in the test. This generated an error that made the method return an error, going to catch and returning null.

**src/infra/cryptography/jwt-adapter.ts**
```ts
  async decode (token: TokenDecoder.Params): Promise<TokenDecoder.Result> {
    try {
      return jwt.verify(token, this.secret) as JwtPayload // Error
    } catch (e) {
      return null // Catch error and return null
    }
  }
```

With this the received payload had the value of null and made the test pass erroneously.

**src\application\middlewares\auth.ts**
```ts
const payload = await this.tokenService.decode(authorization)

       // payload = null

      if (!payload) { 
        return unauthorized(new InvalidTokenError('Invalid or expired token')) // retorna um status 401 fazendo o teste passar
      }
```