### PR TITLE
chore: config jest for unit and integration tests

### DIFF
--- a/jest-integration-config.js
+++ b/jest-integration-config.js
@@ -1,0 +1,3 @@
+const config = require('./jest.config.js')
+config.testMatch = ['**/*.test.ts']
+module.exports = config

--- a/jest-unit-config.js
+++ b/jest-unit-config.js
@@ -1,0 +1,3 @@
+const config = require('./jest.config.js')
+config.testMatch = ['**/*.spec.ts']
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:verbose": "jest --passWithNoTests --no-cache --runInBand",
     "test:staged": "yarn test --findRelatedTests",
     "test:coverage": "yarn test:verbose --coverage",
+    "test:unit": "yarn test -c jest-unit-config.js",
+    "test:integration": "yarn test -c jest-integration-config.js",
     "prepare": "husky install"
   },
   "keywords": [],


### PR DESCRIPTION
To solve the problem of the delay in running tests during development, I added two scripts, one to run only integration tests and the other to run only unit tests.