### PR TITLE
Fix/dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "sucrase": "^3.32.0",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.0.2",
     "uuid": "^9.0.0"
   },

--- a/src/main/server.ts
+++ b/src/main/server.ts
@@ -1,4 +1,5 @@
 import './config/module-alias'
+import 'tsconfig-paths/register'
 import app from '@/main/config/app'
 import env from '@/main/config/env'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6113,6 +6113,7 @@ __metadata:
     supertest: ^6.3.3
     swagger-ui-express: ^4.6.2
     ts-jest: ^29.1.0
+    tsconfig-paths: ^4.2.0
     typescript: ^5.0.2
     uuid: ^9.0.0
     validator: ^13.9.0
@@ -7273,6 +7274,17 @@ __metadata:
     minimist: ^1.2.6
     strip-bom: ^3.0.0
   checksum: a6162eaa1aed680537f93621b82399c7856afd10ec299867b13a0675e981acac4e0ec00896860480efc59fc10fd0b16fdc928c0b885865b52be62cadac692447
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "tsconfig-paths@npm:4.2.0"
+  dependencies:
+    json5: ^2.2.2
+    minimist: ^1.2.6
+    strip-bom: ^3.0.0
+  checksum: 28c5f7bbbcabc9dabd4117e8fdc61483f6872a1c6b02a4b1c4d68c5b79d06896c3cc9547610c4c3ba64658531caa2de13ead1ea1bf321c7b53e969c4752b98c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The "dev" script had a problem: it only worked if the "build" script had been run first. This problem occurred because of the import alias. Sucrase, which we used to run the code, was unable to resolve imports using the import alias.

To solve the problem, I found the `tsconfig-paths` package, which solves this import alias problem in typescript.

**src/main/server.ts**
```ts
import './config/module-alias'
import `tsconfig-paths/register` // adding the package
import app from '@/main/config/app'
import env from '@/main/config/env'

app.listen(env.port, () => { console.log(`Server running at http://localhost:${env.port}`) })
```