### PR TITLE
refactor: change pet gender type to enum PetGender

### DIFF
--- a/src/application/validation/validators/pet-gender-validation.ts
+++ b/src/application/validation/validators/pet-gender-validation.ts
@@ -1,4 +1,5 @@
 import { InvalidParamError } from '@/application/errors'
+import { PetGender } from '@/domain/models/Pet'
 
 export class PetGenderValidation {
   constructor (
@@ -12,7 +13,7 @@ export class PetGenderValidation {
       return new InvalidParamError(this.fieldName)
     }
 
-    if (!['M', 'F'].includes(gender.toUpperCase())) {
+    if (!Object.values(PetGender).includes(input[this.fieldName])) {
       return new InvalidParamError(this.fieldName)
     }
   }

--- a/src/data/protocols/db/pet/add-pet-repository.ts
+++ b/src/data/protocols/db/pet/add-pet-repository.ts
@@ -1,3 +1,4 @@
+import { type PetGender } from '@/domain/models/Pet'
 import { type Guardian } from '@/domain/models/guardian'
 import { type Specie } from '@/domain/models/specie'
 
@@ -11,7 +12,7 @@ export namespace AddPetRepository {
     specieId: string
     specieAlias?: string
     petName: string
-    gender: string
+    gender: PetGender
   }
 
   type GuardianResultDb = Pick<Guardian, 'firstName' | 'lastName' | 'email' | 'phone'> & {

--- a/src/data/use-cases/pet/db-add-pet.ts
+++ b/src/data/use-cases/pet/db-add-pet.ts
@@ -1,5 +1,6 @@
 import { NotAcceptableError } from '@/application/errors'
 import { type AddPetRepository, type LoadGuardianByIdRepository } from '@/data/protocols'
+import { type PetGender } from '@/domain/models/Pet'
 import { type Guardian } from '@/domain/models/guardian'
 import { type Specie } from '@/domain/models/specie'
 import { type AppointSpecie, type AddPet } from '@/domain/use-cases'
@@ -44,7 +45,7 @@ export class DbAddPet implements AddPet {
         specie: pet?.specie as Specie & { id: string },
         specieAlias: pet?.specieAlias,
         petName: pet?.petName as string,
-        gender: pet?.gender as string
+        gender: pet?.gender as PetGender
       }
     }
   }

--- a/src/domain/models/Pet.ts
+++ b/src/domain/models/Pet.ts
@@ -1,0 +1,9 @@
+export enum PetGender {
+  MALE = 'M',
+  FEMALE = 'F'
+}
+
+export type Pet = {
+  petName: string
+  gender: PetGender
+}

--- a/src/domain/use-cases/pet/add-pet.ts
+++ b/src/domain/use-cases/pet/add-pet.ts
@@ -1,5 +1,6 @@
 import { type AddPetRepository, type LoadGuardianByIdRepository } from '@/data/protocols'
 import { type AppointSpecie } from './appoint-specie'
+import { type PetGender } from '@/domain/models/Pet'
 
 export interface AddPet {
   add: (petData: AddPet.Params) => Promise<AddPet.Result>
@@ -10,7 +11,7 @@ export namespace AddPet {
     guardianId: string
     specieName: string
     petName: string
-    gender: string
+    gender: PetGender
   }
 
   export interface Result {

--- a/tests/src/data/use-cases/pet/db-add-pet.spec.ts
+++ b/tests/src/data/use-cases/pet/db-add-pet.spec.ts
@@ -1,6 +1,7 @@
 import { NotAcceptableError } from '@/application/errors'
 import { type AddPetRepository, type LoadGuardianByIdRepository } from '@/data/protocols'
 import { DbAddPet } from '@/data/use-cases'
+import { PetGender } from '@/domain/models/Pet'
 import { type AppointSpecie, type AddPet } from '@/domain/use-cases'
 import {
   makeFakeAppointSpecieUseCase,
@@ -41,7 +42,7 @@ describe('DbAddPet Use Case', () => {
   const params: AddPet.Params = {
     guardianId: 'any_guardian_id',
     specieName: 'any_specie_name',
-    gender: 'M',
+    gender: PetGender.MALE,
     petName: 'any_pet_name'
   }
 

--- a/tests/src/infra/repos/postgresql/pet-repository.spec.ts
+++ b/tests/src/infra/repos/postgresql/pet-repository.spec.ts
@@ -1,3 +1,4 @@
+import { PetGender } from '@/domain/models/Pet'
 import { PetRepository } from '@/infra/repos/postgresql'
 import { prisma as db } from '@/infra/repos/postgresql/prisma'
 import { PrismaHelper } from '@/tests/helpers/prisma-helper'
@@ -18,7 +19,7 @@ describe('PetRepository', () => {
       specieId: 'invalid_specie_id',
       specieAlias: 'invalid_specie_alias',
       petName: 'invalid_pet_name',
-      gender: 'invalid_gender'
+      gender: 'invalid_gender' as PetGender
     }
 
     const specie = await sut.add(data)
@@ -48,7 +49,7 @@ describe('PetRepository', () => {
       specieId: specieFK.id,
       specieAlias: 'any_specie_alias',
       petName: 'any_pet_name',
-      gender: 'M'
+      gender: PetGender.MALE
     }
 
     const specie = await sut.add(data)

--- a/tests/utils/mocks/request.mock.ts
+++ b/tests/utils/mocks/request.mock.ts
@@ -1,4 +1,5 @@
 import { type TokenDecoder } from '@/data/protocols'
+import { PetGender } from '@/domain/models/Pet'
 import {
   type AuthMiddlewareRequest,
   type LoginRequest,
@@ -86,7 +87,7 @@ const makeFakePetRegistryRequest = (): PetRegistryRequest => {
     specieName: 'valid_specie_id',
     specieAlias: 'any_alias',
     petName: 'any_name',
-    gender: 'M'
+    gender: PetGender.MALE
   }
 
   return { body }


### PR DESCRIPTION
I created a `PetGender` enum and added it to the code to validate and standardize the pet gender values. The Pet table still has the `string` type in the `gender` field