### PR TITLE
fix: change the cat size on seed

### DIFF
--- a/src/infra/repos/postgresql/prisma/seeds/size-seed.ts
+++ b/src/infra/repos/postgresql/prisma/seeds/size-seed.ts
@@ -33,10 +33,10 @@ export async function sizeSeed (): Promise<void> {
       }
     }),
     await prisma.size.upsert({
-      where: { name: 'Grande (25 à 45Kg)' },
+      where: { name: 'Grande (25 à 44Kg)' },
       update: {},
       create: {
-        name: 'Grande (25 à 45Kg)',
+        name: 'Grande (25 à 44Kg)',
         specieId: cat.id
       }
     })


### PR DESCRIPTION
o size Grande estava exatamente igual ao de cachorro, por conta disso o size para cachorro não funcionava pois a seed só cadastrava para gato.