### PR TITLE
Fix Prisma v6 config: remove invalid seed property

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -2,6 +2,6 @@ import 'dotenv/config'
 import { defineConfig } from '@prisma/config'
 
 export default defineConfig({
-  schema: './src/infra/repos/postgresql/prisma/schema.prisma',
-  seed: 'sucrase-node ./src/infra/repos/postgresql/prisma/seed.ts'
+  schema: './src/infra/repos/postgresql/prisma/schema.prisma'
 })
+


### PR DESCRIPTION
## Problem\nBuild was failing with TypeScript error:\n\n\n## Root Cause\nThe  property is not a valid configuration option in Prisma v6's  type. This property was removed in recent Prisma versions.\n\n## Solution\nRemoved the invalid  property from . The seed functionality should be managed separately via the  command if needed, which reads from  or a dedicated seed script.\n\n## Changes\n- Removed  from \n- Kept the schema path configuration which is valid and required